### PR TITLE
Database healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Mabede
 
 Mabede is a database accessible through a Node.js API.
-Always use the datetime format `YYYY-MM-DD hh:mm:ss` in the requests.
+Always use the datetime format `YYYY-MM-DD hh:mm:ss` in the request bodies.
 
 Start the application in **production**:
 ```
-docker-compose up -d --build
+docker-compose up -d
 ```
 
 Start the application in **development**:
 ```
-docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d --build
+docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d
 ```
 
 Stop the application:
@@ -18,8 +18,7 @@ Stop the application:
 docker-compose down
 ```
 
-The `--build` flag rebuilds the image every time the application starts.
-Without this flag, updating the image requires deleting it before starting.
+Delete the image created with docker-compose:
 ```
 docker image rm mabede-mabede
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     env_file:
       - ./env/database.env
     depends_on:
-      - database
+      database:
+        condition: service_healthy
 
   database:
     container_name: database
@@ -24,6 +25,12 @@ services:
       - ./env/database.env
     volumes:
       - mabede-database:/var/lib/mysql
+    healthcheck:
+      test: "mysqladmin ping --silent"
+      interval: 0s
+      timeout: 2s
+      retries: 10
+      start_period: 0s
 
 volumes:
   mabede-database:


### PR DESCRIPTION
The healthcheck ensures that the API's container `mabede` starts only when the MySQL container `database` is available.