### PR TITLE
Class MabedeError is in its own module

### DIFF
--- a/mabede/src/database.js
+++ b/mabede/src/database.js
@@ -1,20 +1,13 @@
 const mysql = require("mysql2");
 
+const MabedeError = require("./mabede-error");
+
 const EMPTY_STR = "";
 const SPACE = " ";
 const UC_T = "T";
 
 const INVALID_IDS_MESSAGE = "IDs: an empty request body or an array of integers is required.";
 const TYPE_STRING = "string";
-
-class MabedeError {
-	constructor(statusCode, content) {
-		this.statusCode = statusCode;
-		this.content = content;
-	}
-
-	toString = () => `[${this.statusCode}] ${this.content}`;
-}
 
 const pool = mysql.createPool({
 	host: process.env.MYSQL_HOST,

--- a/mabede/src/mabede-error.js
+++ b/mabede/src/mabede-error.js
@@ -1,0 +1,10 @@
+class MabedeError {
+	constructor(statusCode, content) {
+		this.statusCode = statusCode;
+		this.content = content;
+	}
+
+	toString = () => `[${this.statusCode}] ${this.content}`;
+}
+
+module.exports = MabedeError;


### PR DESCRIPTION
Since `MabedeError` instances are used in more than one file, it makes sense to move the class to a separate module.